### PR TITLE
fix(vue-next): kebab-case attrs render

### DIFF
--- a/packages/vue-next/CHANGELOG.md
+++ b/packages/vue-next/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 0.0.7 `2022-02-25`
+
+### Bug Fixes
+
+- 修复按需引入方式使用部分图标，由于`fillOpacity`, `fillRule`, `clipRule`属性加载异常导致的问题
+
 ## 0.0.6 `2022-01-18`
 
 ### Bug Fixes

--- a/packages/vue-next/package.json
+++ b/packages/vue-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tdesign-icons-vue-next",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "files": [
     "dist",
     "esm",

--- a/packages/vue-next/src/utils/render-fn.ts
+++ b/packages/vue-next/src/utils/render-fn.ts
@@ -1,11 +1,22 @@
 import { VNode, h } from 'vue';
 import { SVGJson } from './types';
 
+function camel2Kebab(camelString:string) {
+  const covertArr = ['fillOpacity', 'fillRule', 'clipRule'];
+  if (covertArr.includes(camelString)) { return camelString.replace(/([a-z0-9]|(?=[A-Z]))([A-Z])/g, '$1-$2').toLowerCase(); }
+  return camelString;
+}
+
 function renderFn(node: SVGJson, props:Record<string, any>): VNode {
+  const kebabAttrs = Object.keys(node.attrs).reduce((result, key) => {
+    // eslint-disable-next-line no-param-reassign
+    result[camel2Kebab(key)] = node.attrs[key];
+    return result;
+  }, {});
   return h(
     node.tag,
     {
-      ...node.attrs,
+      ...kebabAttrs,
       ...props,
     },
     (node.children || []).map((child: SVGJson) => renderFn(child, {})),


### PR DESCRIPTION
修复`icons-vue-next`按需引入方式使用部分图标，由于`fillOpacity`, `fillRule`, `clipRule`属性加载异常导致的问题