### PR TITLE
修正图标组件宿主元素占位空间

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@
 **/dist/
 **/lib/
 **/esm/
+**/template/

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ yarn-error.log
 # lock
 packages/**/yarn.lock
 packages/**/package-lock.json
+
+# webstorm
+.idea/

--- a/packages/angular/gulp/template/icon.component.ts
+++ b/packages/angular/gulp/template/icon.component.ts
@@ -1,9 +1,12 @@
-import { Component, ChangeDetectionStrategy, Input, ViewEncapsulation } from '@angular/core';
+import {
+  Component, ChangeDetectionStrategy, Input, ViewEncapsulation, HostBinding,
+} from '@angular/core';
 import {
   NgStyleInterface,
   NgClassInterface,
   TIconStandaloneComponent,
   TIconSize,
+// @ts-ignore
 } from '../tdesign-icons-angular.component';
 
 @Component({
@@ -12,15 +15,19 @@ import {
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: '$SVG',
-  host: {
-    '[attr.data-t-icon]': 'true',
-    '[style.line-height]': '0',
-  },
 })
 export class TIcon$ICON_NAMEComponent extends TIconStandaloneComponent {
   @Input() public styles?: NgStyleInterface;
+
   @Input() public classes?: NgClassInterface;
+
   @Input() public size: string | TIconSize = 'default';
+
+  @HostBinding('attr.data-t-icon') protected hostAttrDataTIcon = true;
+
+  @HostBinding('style.line-height') protected hostStyleLineHeight = 0;
+
+  @HostBinding('style.display') protected hostStyleDisplay = 'inline-block';
 
   protected name = '$KEY';
 }

--- a/packages/angular/projects/tdesign-icons-angular/src/lib/tdesign-icons-angular.component.ts
+++ b/packages/angular/projects/tdesign-icons-angular/src/lib/tdesign-icons-angular.component.ts
@@ -4,7 +4,6 @@ import {
   ViewEncapsulation,
   OnChanges,
   Component,
-  Directive,
   OnInit,
   HostBinding,
 } from '@angular/core';
@@ -39,11 +38,12 @@ export interface NgClassInterface {
 }
 
 export abstract class TIconCommonBase {
+  // tslint:disable-next-line:variable-name
   public _classes: NgClassInterface = {};
+  // tslint:disable-next-line:variable-name
   public _styles: NgStyleInterface = {};
 }
 
-@Directive()
 /**
  * all standalone icons should inherit this component
  */
@@ -52,8 +52,9 @@ export abstract class TIconStandaloneComponent
   implements OnInit, OnChanges {
   protected abstract styles?: NgStyleInterface;
   protected abstract classes?: NgClassInterface;
-  protected abstract size: string | TIconSize = 'default';
   protected abstract name: string;
+
+  protected size: string | TIconSize = 'default';
 
   public ngOnInit(): void {
     this.updateStyle();
@@ -98,9 +99,7 @@ export abstract class TIconStandaloneComponent
 export class TIconComponent extends TIconCommonBase implements OnChanges {
   @Input() public svg?: string;
   @Input() public iconfont?: string;
-
   @Input() public size: string | TIconSize = 'default';
-
   @Input() public styles?: NgStyleInterface;
   @Input() public classes?: NgClassInterface;
 

--- a/packages/angular/projects/tdesign-icons-angular/src/lib/tdesign-icons-angular.component.ts
+++ b/packages/angular/projects/tdesign-icons-angular/src/lib/tdesign-icons-angular.component.ts
@@ -6,6 +6,7 @@ import {
   Component,
   Directive,
   OnInit,
+  HostBinding,
 } from '@angular/core';
 import { TIconService } from './tdesign-icons-angular.service';
 
@@ -102,6 +103,9 @@ export class TIconComponent extends TIconCommonBase implements OnChanges {
 
   @Input() public styles?: NgStyleInterface;
   @Input() public classes?: NgClassInterface;
+
+  @HostBinding('style.line-height') protected hostStyleLineHeight = 0;
+  @HostBinding('style.display') protected hostStyleDisplay = 'inline-block';
 
   public isSvgIcon = false;
 

--- a/packages/angular/projects/tdesign-icons-angular/tslint.json
+++ b/packages/angular/projects/tdesign-icons-angular/tslint.json
@@ -4,13 +4,13 @@
     "directive-selector": [
       true,
       "attribute",
-      "lib",
+      "t-icon",
       "camelCase"
     ],
     "component-selector": [
       true,
       "element",
-      "lib",
+      "t-icon",
       "kebab-case"
     ]
   }

--- a/packages/angular/tslint.json
+++ b/packages/angular/tslint.json
@@ -1,5 +1,10 @@
 {
   "extends": "tslint:recommended",
+  "linterOptions": {
+    "exclude": [
+      "gulp/template/**/*.ts"
+    ]
+  },
   "rulesDirectory": [
     "codelyzer"
   ],


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [x] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

目前 `t-icon` 组件结构如下

```html
<t-icon(-*)?>
  <svg>xxx</svg>
</t-icon(-*)?>
```

问题表现为 `t-icon(-*)?` 标签高度比 `<svg>` 标签高，导致组件视觉上不居中。

具体解决方法为设置宿主元素 `display` 属性 `inline` -> `inline-block` 

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(t-icon(-*)?): 修正图标组件宿主元素占位空间

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
