### PR TITLE
fix(tdesign_icons): 将 pubspec 字体族名与 TIcons 生成代码对齐

### DIFF
--- a/packages/flutter/CHANGELOG.md
+++ b/packages/flutter/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.0.4] - 2026-06-03
+
+- fix: 将 pubspec 字体族名 `TDIcons` 改为 `TIcons`，与生成代码 `IconData.fontFamily` 一致
+
 ## [0.0.3] - 2026-06-03
 
 - `TDIcons` 类名改为 `TIcons`

--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: tdesign_icons
 description: "TDesign Icons for Flutter."
-version: 0.0.3
+version: 0.0.4
 homepage: https://tdesign.tencent.com/icons
 repository: https://github.com/Tencent/tdesign-icons/tree/develop/packages/flutter
 issue_tracker: https://github.com/Tencent/tdesign-icons/issues
@@ -32,6 +32,6 @@ dev_dependencies:
 
 flutter:
   fonts:
-    - family: TDIcons
+    - family: TIcons
       fonts:
         - asset: fonts/t.ttf


### PR DESCRIPTION
0.0.3 仅重命名了 Dart 类与 IconData.fontFamily，pubspec 仍注册 TDIcons， 导致图标无法渲染；版本升至 0.0.4。

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(tdesign_icons): 将 pubspec 字体族名与 TIcons 生成代码对齐

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
