### PR TITLE
chore(flutter): trim published package files

### DIFF
--- a/packages/flutter/.pubignore
+++ b/packages/flutter/.pubignore
@@ -1,13 +1,12 @@
 .DS_Store
 .changelog
 .dart_tool/
+analysis_options.yaml
 build/
+CONTRIBUTING.md
 pubspec.lock
-example/pubspec.lock
-example/.dart_tool/
-example/build/
-example/android/.gradle/
-example/android/.kotlin/
+example/
+tool/
 
 !fonts/
 !fonts/t.ttf


### PR DESCRIPTION
## Summary

- exclude the empty local `example` tree from the Flutter package archive
- exclude contributor-only analysis, contribution, and generation files
- keep generated font and `assets.g.dart` included for publication

## Verification

- `flutter pub publish --dry-run`
- package contains only metadata, documentation, font, and library files
- package validation reports 0 warnings