### PR TITLE
fix: correct icon view component names

### DIFF
--- a/packages/view/.changelog/pr-288.md
+++ b/packages/view/.changelog/pr-288.md
@@ -1,0 +1,6 @@
+---
+pr_number: 288
+contributor: liweijie0812
+---
+
+- fix: 修复 React 和 Vue 图标组件名复制时的大小写及数字分隔问题 @liweijie0812 ([#288](https://github.com/Tencent/tdesign-icons/pull/288))

--- a/packages/view/src/icon-view.vue
+++ b/packages/view/src/icon-view.vue
@@ -350,6 +350,7 @@ import {
   anchorHighlight,
   appendStyleSheet,
   kebabToPascal,
+  pascalToKebab,
 } from './utils/index';
 import { manifest as manifestSrc } from './manifest';
 import SvgSprite from '../gulp/template/svg-sprite.vue';
@@ -558,6 +559,7 @@ const getCurrentRawSvg = () => {
 
 const handleCopyIcon = async (type) => {
   const isSingleColor = configuration.colorType === 'single';
+  const componentName = `${kebabToPascal(currentIconName.value)}Icon`;
 
   const fillColor = isSingleColor
     ? configuration.fillColor1
@@ -571,7 +573,7 @@ const handleCopyIcon = async (type) => {
       const fillText = !isSingleColor ? fillColor : `"${fillColor}"`;
       const strokeText = !isSingleColor ? strokeColor : `"${strokeColor}"`;
       await navigator.clipboard.writeText(
-        `<${currentIconName.value}-icon :fill-color='${fillText}' :stroke-color='${strokeText}' :stroke-width="${configuration.strokeWidth}"/>`,
+        `<${pascalToKebab(componentName)} :fill-color='${fillText}' :stroke-color='${strokeText}' :stroke-width="${configuration.strokeWidth}"/>`,
       );
     } else if (type === 'react') {
       const fillText = !isSingleColor ? `{${fillColor}}` : `'${fillColor}'`;
@@ -579,9 +581,7 @@ const handleCopyIcon = async (type) => {
         ? `{${strokeColor}}`
         : `'${strokeColor}'`;
       await navigator.clipboard.writeText(
-        `<${kebabToPascal(
-          currentIconName.value,
-        )}Icon fillColor=${fillText} strokeColor=${strokeText} strokeWidth={${
+        `<${componentName} fillColor=${fillText} strokeColor=${strokeText} strokeWidth={${
           configuration.strokeWidth
         }}/>`,
       );

--- a/packages/view/src/utils/index.js
+++ b/packages/view/src/utils/index.js
@@ -9,11 +9,18 @@ export function getRoot() {
 }
 
 export function kebabToPascal(str) {
-  const words = str.split('-');
+  return str
+    .split('-')
+    .map((word) => word.replace(/(^|\d)([a-z])/g, (_, prefix, letter) => `${prefix}${letter.toUpperCase()}`))
+    .join('');
+}
 
-  const capitalizedWords = words.map((word) => word.charAt(0).toUpperCase() + word.slice(1));
-
-  return capitalizedWords.join('');
+export function pascalToKebab(str) {
+  return str
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/([A-Z])([A-Z][a-z])/g, '$1-$2')
+    .replace(/([a-zA-Z])(\d)/g, '$1-$2')
+    .toLowerCase();
 }
 
 export function appendStyleSheet() {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
- https://github.com/Tencent/tdesign-icons/issues/181

React 复制（大小写错误）：页面手写的 kebabToPascal 把 chart-3d 转成 Chart3d，但构建侧（gulp/util 的 camelcase）实际生成的组件名是 Chart3DIcon。复制的 <Chart3dIcon/> 根本不存在。

受影响 8 个图标：chart-3d、chart-3d-filled、map-3d、map-3d-filled、logo-cinema4d、logo-cinema4d-filled、screen-4k、screen-4k-filled
Vue 复制（同样错误）：页面直接拼 {iconName}-icon（如 chart-3d-icon），但 Vue 组件实际注册名是 Chart3DIcon，模板正确写法应为 chart-3-d-icon。chart-3d-icon 无法被 Vue 解析。


### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### all

<!--
- feat(组件名称): 处理问题或特性描述
-->

#### tdesign-icons-vue-next

<!--
- feat(组件名称): 处理问题或特性描述
-->

#### tdesign-icons-react

<!--
- feat(组件名称): 处理问题或特性描述
-->

#### tdesign-icons-vue

<!--
- feat(组件名称): 处理问题或特性描述
-->

#### tdesign-icons-web-components

<!--
- feat(组件名称): 处理问题或特性描述
-->

#### tdesign-icons-svg

<!--
- feat(组件名称): 处理问题或特性描述
-->

#### tdesign-icons-view

<!--
- feat(组件名称): 处理问题或特性描述
-->
- fix: 修复 React 和 Vue 图标组件名复制时的大小写及数字分隔问题

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
