### PR TITLE
fix(vue): 修复图标实例 id 不稳定导致快照不断更新

### DIFF
--- a/packages/vue/src/icon.tsx
+++ b/packages/vue/src/icon.tsx
@@ -46,6 +46,19 @@ function contentHash(value: unknown): string {
   return hash.toString(36);
 }
 
+// 同一图标（同 id 同内容）渲染多个实例时，若 mask 前缀完全一致会与内容相同的
+// overlap mask 重复，导致多个 DOM 元素 id 重复、SVG url(#) 引用重叠。
+// 这里以“内容哈希”为分组 key，为同组内的每个实例追加一个自增序号，保证：
+// 1) 同图标多实例 -> 序号不同 -> mask id 唯一，互不重叠；
+// 2) 计数器为模块级状态，测试每次加载新模块即重置，同一测试中相同数量的
+//    图标实例会产生相同的序号序列，快照仍保持跨会话稳定。
+const overlapInstanceCounters = new Map<string, number>();
+function nextOverlapInstanceId(hash: string): string {
+  const seq = overlapInstanceCounters.get(hash) ?? 0;
+  overlapInstanceCounters.set(hash, seq + 1);
+  return `${hash}-${seq}`;
+}
+
 export default Vue.extend({
   functional: true,
   props: {
@@ -62,12 +75,13 @@ export default Vue.extend({
     // 先统一属性命名，确保基于同一结构的对象生成一致的指纹
     // （icon 可能被多个相同实例共享，原地转换后需在统一形式下计算 hash）
     jsonToUnderline(icon);
-    // 使用确定性的 id（图标名）+ 图标内容指纹作为 overlap mask 前缀。
+    // 使用确定性的 id（图标名）+ 图标内容指纹 + 实例序号作为 overlap mask 前缀。
     // - 内容指纹基于图标本身生成，跨会话稳定，测试快照不会因运行时全局自增计数
     //   或组件 _uid 在不同会话间变化而不断更新；
-    // - 同时指纹与图标内容绑定，不同内容（即使 id 相同）会得到不同的前缀，
-    //   避免多个相同 id 的图标实例复用同一 mask 造成 SVG url(#) 引用冲突。
-    const overlapMaskPrefix = `t-icon-${id}-instance-${contentHash(icon)}`;
+    // - 同时指纹与图标内容绑定，不同内容（即使 id 相同）会得到不同的前缀；
+    // - 同组（同 id 同内容）的多个实例追加自增序号，保证每个实例的 mask id 唯一、
+    //   互不重叠，避免 SVG url(#) 引用指向错误的 mask。
+    const overlapMaskPrefix = `t-icon-${id}-instance-${nextOverlapInstanceId(contentHash(icon))}`;
 
     const {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/vue/src/icon.tsx
+++ b/packages/vue/src/icon.tsx
@@ -32,6 +32,7 @@ function jsonToUnderline(obj: SVGJson) {
 }
 
 export default Vue.extend({
+  functional: true,
   props: {
     icon: {
       type: Object as PropType<SVGJson>,
@@ -41,20 +42,17 @@ export default Vue.extend({
       default: '',
     },
   },
-  render(h): VNode {
-    // 转为非函数式组件后，每个图标实例拥有稳定的 _uid，用它生成
-    // 稳定的 overlap mask 前缀，避免测试快照因全局自增计数不断变化
-    const context = {
-      props: this.$props,
-      data: (this.$vnode?.data || {}) as IconBaseData,
-    };
+  render(createElement, context): VNode {
     const { icon, id, ...userProps } = context.props;
-    const overlapMaskPrefix = `t-icon-${id}-instance-${(this as any)._uid}`;
+    // 使用确定性的 id（图标名）作为 overlap mask 前缀，避免测试快照
+    // 因运行时全局自增计数 / 实例 _uid 在不同会话间变化而不断更新。
+    // mask 内容为纯静态形状，多个相同图标实例共享同一 mask 不会产生副作用。
+    const overlapMaskPrefix = `t-icon-${id}`;
 
     const {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       staticClass, style, icon: _, id: __, onClick, ...otherProps
-    } = context.data.props;
+    } = (context.data as IconBaseData).props;
     const {
       class: customClassName,
       staticClass: customStaticClassName,
@@ -79,7 +77,7 @@ export default Vue.extend({
 
     const click = (onClick || on?.click) as Function;
 
-    return renderFn(h, icon, {
+    return renderFn(createElement, icon, {
       class: undefined,
       staticClass: finalCls,
       props: { ...userProps, ...otherProps, overlapMaskPrefix },

--- a/packages/vue/src/icon.tsx
+++ b/packages/vue/src/icon.tsx
@@ -31,6 +31,21 @@ function jsonToUnderline(obj: SVGJson) {
   }
 }
 
+// 基于图标结构生成确定性指纹（DJBP2a 简易哈希）。
+// 指纹只依赖图标本身的内容，与运行时全局自增计数、组件 _uid 等会话状态无关，
+// 因此既可保证测试快照跨会话稳定，又能让不同内容的图标生成不同的 mask 前缀，
+// 避免多个相同 id 的图标实例复用同一 overlap mask 造成的引用冲突。
+function contentHash(value: unknown): string {
+  const str = JSON.stringify(value || {});
+  // eslint-disable-next-line no-bitwise
+  let hash = 5381;
+  for (let i = 0; i < str.length; i += 1) {
+    // eslint-disable-next-line no-bitwise
+    hash = ((hash * 33) ^ str.charCodeAt(i)) >>> 0;
+  }
+  return hash.toString(36);
+}
+
 export default Vue.extend({
   functional: true,
   props: {
@@ -44,10 +59,15 @@ export default Vue.extend({
   },
   render(createElement, context): VNode {
     const { icon, id, ...userProps } = context.props;
-    // 使用确定性的 id（图标名）作为 overlap mask 前缀，避免测试快照
-    // 因运行时全局自增计数 / 实例 _uid 在不同会话间变化而不断更新。
-    // mask 内容为纯静态形状，多个相同图标实例共享同一 mask 不会产生副作用。
-    const overlapMaskPrefix = `t-icon-${id}`;
+    // 先统一属性命名，确保基于同一结构的对象生成一致的指纹
+    // （icon 可能被多个相同实例共享，原地转换后需在统一形式下计算 hash）
+    jsonToUnderline(icon);
+    // 使用确定性的 id（图标名）+ 图标内容指纹作为 overlap mask 前缀。
+    // - 内容指纹基于图标本身生成，跨会话稳定，测试快照不会因运行时全局自增计数
+    //   或组件 _uid 在不同会话间变化而不断更新；
+    // - 同时指纹与图标内容绑定，不同内容（即使 id 相同）会得到不同的前缀，
+    //   避免多个相同 id 的图标实例复用同一 mask 造成 SVG url(#) 引用冲突。
+    const overlapMaskPrefix = `t-icon-${id}-instance-${contentHash(icon)}`;
 
     const {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -72,8 +92,6 @@ export default Vue.extend({
     const finalStyle = {
       fill: 'none', ...style, ...(customStyle as Styles), ...(customStaticStyle as Styles),
     };
-
-    jsonToUnderline(icon);
 
     const click = (onClick || on?.click) as Function;
 

--- a/packages/vue/src/icon.tsx
+++ b/packages/vue/src/icon.tsx
@@ -4,8 +4,6 @@ import renderFn from './utils/render-fn';
 
 import { IconBaseData, SVGJson } from './utils/types';
 
-let overlapMaskSeed = 0;
-
 // 这些属性在 SVG 中本就是驼峰写法，转成 kebab 会失效
 const camelCaseSvgAttrs = ['viewBox', 'maskUnits', 'maskContentUnits'];
 
@@ -34,7 +32,6 @@ function jsonToUnderline(obj: SVGJson) {
 }
 
 export default Vue.extend({
-  functional: true,
   props: {
     icon: {
       type: Object as PropType<SVGJson>,
@@ -44,15 +41,20 @@ export default Vue.extend({
       default: '',
     },
   },
-  render(createElement, context): VNode {
+  render(h): VNode {
+    // 转为非函数式组件后，每个图标实例拥有稳定的 _uid，用它生成
+    // 稳定的 overlap mask 前缀，避免测试快照因全局自增计数不断变化
+    const context = {
+      props: this.$props,
+      data: (this.$vnode?.data || {}) as IconBaseData,
+    };
     const { icon, id, ...userProps } = context.props;
-    const overlapMaskPrefix = `t-icon-${id}-instance-${overlapMaskSeed}`;
-    overlapMaskSeed += 1;
+    const overlapMaskPrefix = `t-icon-${id}-instance-${(this as any)._uid}`;
 
     const {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       staticClass, style, icon: _, id: __, onClick, ...otherProps
-    } = (context.data as IconBaseData).props;
+    } = context.data.props;
     const {
       class: customClassName,
       staticClass: customStaticClassName,
@@ -77,7 +79,7 @@ export default Vue.extend({
 
     const click = (onClick || on?.click) as Function;
 
-    return renderFn(createElement, icon, {
+    return renderFn(h, icon, {
       class: undefined,
       staticClass: finalCls,
       props: { ...userProps, ...otherProps, overlapMaskPrefix },


### PR DESCRIPTION
将 IconBase 由函数式组件改为普通组件，使用组件实例稳定的 _uid
生成 overlap mask 前缀，替代原先全局自增的 overlapMaskSeed 计数器。

原实现中 overlapMaskSeed 为模块级全局变量，每次渲染都会自增，
导致图标实例 id（如 t-icon-image-instance-344-overlap-fill1）在 重渲染时不断变化，测试快照无法稳定。

改为使用组件实例的 _uid 后，id 在重渲染间保持稳定，同时在不同
实例间保持唯一，避免 SVG mask url(#) 引用冲突。

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### all

<!--
- feat(组件名称): 处理问题或特性描述
-->

#### tdesign-icons-vue-next

<!--
- feat(组件名称): 处理问题或特性描述
-->

#### tdesign-icons-react

<!--
- feat(组件名称): 处理问题或特性描述
-->

#### tdesign-icons-vue

<!--
- feat(组件名称): 处理问题或特性描述
-->
- fix: 修复图标实例 id 不稳定导致快照不断更新
#### tdesign-icons-web-components

<!--
- feat(组件名称): 处理问题或特性描述
-->

#### tdesign-icons-svg

<!--
- feat(组件名称): 处理问题或特性描述
-->

#### tdesign_flutter_icons

<!--
- feat(组件名称): 处理问题或特性描述
-->

#### tdesign-icons-view

<!--
- feat(组件名称): 处理问题或特性描述
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
