### PR TITLE
fix(view): handle ID-based monochrome fill icons by replacing hardcoded fill color

### DIFF
--- a/packages/view/.changelog/pr-299.md
+++ b/packages/view/.changelog/pr-299.md
@@ -1,0 +1,6 @@
+---
+pr_number: 299
+contributor: liweijie0812
+---
+
+- fix: 修复带 id 的单色填充图标（如 `caret-down-small`）硬编码黑色 fill 未替换为主题色，导致深色模式下渲染为纯黑的问题 @liweijie0812 ([#299](https://github.com/Tencent/tdesign-icons/pull/299))

--- a/packages/view/gulp/generate-view-svg-sprite.ts
+++ b/packages/view/gulp/generate-view-svg-sprite.ts
@@ -117,6 +117,21 @@ export function processSvgSpriteInNode(svgString) {
         }
       } else if (isLogo) {
         element.setAttribute('fill', isSpecified ? 'currentColor' : 'transparent');
+      } else {
+        // 单色填充图标（带有 id 但不是 strokeN/fillN 多色路径，如 caret-down-small）：
+        //
+        // 问题链路：
+        // 1. 源文件 svg/caret-down-small.svg 中 path 硬编码了 fill="black"，
+        //    经 svgo 处理后会被归一化为 fill="#000"（黑）。
+        // 2. 该 path 自带 id（如 ambcaret-down-small），因此会进入上方 else if (nodeId)
+        //    分支，但其 id 既不属于 strokeN 也不属于 fillN 多色路径、也不是 logo，
+        //    此前没有任何分支命中，硬编码的 fill="#000" 会被原样保留。
+        // 3. 结果：深色模式下图标仍以纯黑渲染，无法随主题色变化。
+        //
+        // 处理方式：移除硬编码的 fill，并绑定为主题色变量，
+        // 使其跟随组件 props（isSpecified 时为 strokeColor1，否则为 fillColor1）。
+        element.removeAttribute('fill');
+        element.setAttribute(':fill', isSpecified ? 'strokeColor1' : 'fillColor1');
       }
     } else {
       // 填充图标处理逻辑

--- a/packages/view/gulp/generate-view-svg-sprite.ts
+++ b/packages/view/gulp/generate-view-svg-sprite.ts
@@ -118,18 +118,12 @@ export function processSvgSpriteInNode(svgString) {
       } else if (isLogo) {
         element.setAttribute('fill', isSpecified ? 'currentColor' : 'transparent');
       } else {
-        // 单色填充图标（带有 id 但不是 strokeN/fillN 多色路径，如 caret-down-small）：
-        //
-        // 问题链路：
-        // 1. 源文件 svg/caret-down-small.svg 中 path 硬编码了 fill="black"，
-        //    经 svgo 处理后会被归一化为 fill="#000"（黑）。
-        // 2. 该 path 自带 id（如 ambcaret-down-small），因此会进入上方 else if (nodeId)
-        //    分支，但其 id 既不属于 strokeN 也不属于 fillN 多色路径、也不是 logo，
-        //    此前没有任何分支命中，硬编码的 fill="#000" 会被原样保留。
-        // 3. 结果：深色模式下图标仍以纯黑渲染，无法随主题色变化。
-        //
-        // 处理方式：移除硬编码的 fill，并绑定为主题色变量，
-        // 使其跟随组件 props（isSpecified 时为 strokeColor1，否则为 fillColor1）。
+        // 单色填充图标：path 自带 id（如 caret-down-small 的 ambcaret-down-small），
+        // 但既非 strokeN/fillN 多色路径，也非 logo，上方分支均不命中。
+        // 若保留源文件硬编码的 fill="black"（svgo 会归一化为 fill="#000"），
+        // 图标将无法跟随主题色（深色模式下仍为纯黑），
+        // 故此处移除硬编码 fill，改为绑定主题色变量
+        // （isSpecified 时为 strokeColor1，否则为 fillColor1）。
         element.removeAttribute('fill');
         element.setAttribute(':fill', isSpecified ? 'strokeColor1' : 'fillColor1');
       }

--- a/packages/view/gulp/generate-view-svg-sprite.ts
+++ b/packages/view/gulp/generate-view-svg-sprite.ts
@@ -118,7 +118,7 @@ export function processSvgSpriteInNode(svgString) {
       } else if (isLogo) {
         element.setAttribute('fill', isSpecified ? 'currentColor' : 'transparent');
       } else {
-        // 单色填充图标：path 自带 id（如 caret-down-small 的 ambcaret-down-small），
+        // 单色填充图标：path 自带 id（如 caret-down-small），
         // 但既非 strokeN/fillN 多色路径，也非 logo，上方分支均不命中。
         // 若保留源文件硬编码的 fill="black"（svgo 会归一化为 fill="#000"），
         // 图标将无法跟随主题色（深色模式下仍为纯黑），


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
<img width="4364" height="896" alt="image" src="https://github.com/user-attachments/assets/3bc0cf75-f8ea-41ab-9002-3fa7b2573182" />

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### all

<!--
- feat(组件名称): 处理问题或特性描述
-->

#### tdesign-icons-vue-next

<!--
- feat(组件名称): 处理问题或特性描述
-->

#### tdesign-icons-react

<!--
- feat(组件名称): 处理问题或特性描述
-->

#### tdesign-icons-vue

<!--
- feat(组件名称): 处理问题或特性描述
-->

#### tdesign-icons-web-components

<!--
- feat(组件名称): 处理问题或特性描述
-->

#### tdesign-icons-svg

<!--
- feat(组件名称): 处理问题或特性描述
-->

#### tdesign_flutter_icons

<!--
- feat(组件名称): 处理问题或特性描述
-->

#### tdesign-icons-view

<!--
- feat(组件名称): 处理问题或特性描述
-->
- fix: 修复带 id 的单色填充图标（如 `caret-down-small`）硬编码黑色 fill 未替换为主题色，导致深色模式下渲染为纯黑的问题 
### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
